### PR TITLE
Default instance bug fixed

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/test_collections.py
+++ b/test_collections.py
@@ -1,4 +1,5 @@
 import sys
+import pytest
 sys.path.insert(0, 'utils/')
 
 from utils.collections import Queue
@@ -56,14 +57,18 @@ def test_dequeue_empty():
 
 
 def test_fetch_items():
-    my_queue = Queue()
+    my_queue = Queue([{"sender": "David", "receiver": "Ridwan", "message": "Hello!"}])
     assert my_queue.get_items() == [{"sender": "David", "receiver": "Ridwan", "message": "Hello!"}]
 
 def test_fetch_items_empty():
     my_queue = Queue()
-    my_queue.dequeue()
     assert my_queue.get_items() == []
 
+def test_dequeue_without_items_should_throw_an_exception():
+    my_queue = Queue()
+    with pytest.raises(Exception) as excp:
+        my_queue.dequeue()
+    assert 'The queue is empty' == str(excp.value)
 
 def test_cloning_private_array():
     my_queue = Queue()

--- a/utils/collections.py
+++ b/utils/collections.py
@@ -1,4 +1,4 @@
-class Queue():
+class Queue:
     """
     Queue manager utility class
     ...
@@ -19,7 +19,7 @@ class Queue():
     """
 
 
-    def __init__(self, items=[]):
+    def __init__(self, items = None):
         """
         Parameters
         ----------
@@ -28,8 +28,12 @@ class Queue():
         length : int
             The count of all the elements inside __array
         """
-        self.__array = items
-        self.length = len(items)
+        if items is None:
+            self.__array = []
+            self.length = 0
+        else:
+            self.__array = items
+            self.length = len(items)
     
     def enqueue(self, item):
         """ Adds another element to the queue
@@ -75,7 +79,7 @@ class Queue():
         """
         return Queue(self.__array)
 
-class Stack():
+class Stack:
     """
     Stack manager utility class
 
@@ -99,7 +103,7 @@ class Stack():
     clone()
         Returns a copy of the stack
     """
-    def __init__(self, items=[]):
+    def __init__(self, items=None):
         """
         Parameters
         ----------
@@ -108,8 +112,12 @@ class Stack():
         length : int
             The count of all the elements inside __array
         """
-        self.__array = items
-        self.length = len(items)
+        if items is None:
+            self.__array = []
+            self.length = 0
+        else:
+            self.__array = items
+            self.length = len(items)
     
     def add(self, item):
         """ Adds another element to the queue


### PR DESCRIPTION
- Fixed a bug with the default parameter in the constructor of Stack and Queue class. Now is not a shared object parameter is single for every different instance. This is because you cannot have a mutable object as default parameter, only you can pass immutable objects, just pass None as default value, and done.
- Changed a unit test and added a new one.